### PR TITLE
Deezer track/artist not detected

### DIFF
--- a/content-deezer.js
+++ b/content-deezer.js
@@ -10,6 +10,17 @@
   let currentTrack = '';
   let isSkipping = false;
 
+  function getTrackFromMediaSession() {
+    const metadata = navigator.mediaSession && navigator.mediaSession.metadata;
+    if (!metadata) return null;
+
+    const artist = (metadata.artist || '').trim();
+    const track = (metadata.title || '').trim();
+    if (!artist || !track) return null;
+
+    return { artist, track };
+  }
+
   // Get current track info from Deezer's web player
   function getCurrentTrack() {
     // Method 1: Player bar selectors
@@ -58,6 +69,10 @@
         };
       }
     }
+
+    // Fallback: Media Session metadata
+    const mediaSessionTrack = getTrackFromMediaSession();
+    if (mediaSessionTrack) return mediaSessionTrack;
 
     return null;
   }

--- a/content-spotify.js
+++ b/content-spotify.js
@@ -10,6 +10,17 @@
   let currentTrack = '';
   let isSkipping = false;
 
+  function getTrackFromMediaSession() {
+    const metadata = navigator.mediaSession && navigator.mediaSession.metadata;
+    if (!metadata) return null;
+
+    const artist = (metadata.artist || '').trim();
+    const track = (metadata.title || '').trim();
+    if (!artist || !track) return null;
+
+    return { artist, track };
+  }
+
   // Get current track info from Spotify's web player
   function getCurrentTrack() {
     // Method 1: Now playing bar (most reliable)
@@ -51,6 +62,10 @@
         };
       }
     }
+
+    // Fallback: Media Session metadata
+    const mediaSessionTrack = getTrackFromMediaSession();
+    if (mediaSessionTrack) return mediaSessionTrack;
 
     return null;
   }

--- a/content-youtube-music.js
+++ b/content-youtube-music.js
@@ -10,6 +10,17 @@
   let currentTrack = '';
   let isSkipping = false;
 
+  function getTrackFromMediaSession() {
+    const metadata = navigator.mediaSession && navigator.mediaSession.metadata;
+    if (!metadata) return null;
+
+    const artist = (metadata.artist || '').trim();
+    const track = (metadata.title || '').trim();
+    if (!artist || !track) return null;
+
+    return { artist, track };
+  }
+
   // Get current track info from YouTube Music's web player
   function getCurrentTrack() {
     // Method 1: Player bar at bottom
@@ -58,6 +69,10 @@
         };
       }
     }
+
+    // Fallback: Media Session metadata
+    const mediaSessionTrack = getTrackFromMediaSession();
+    if (mediaSessionTrack) return mediaSessionTrack;
 
     return null;
   }


### PR DESCRIPTION
This MR fixes two causes of the popup showing “No track playing” while music is playing:

### 1. Popup picks wrong tab

**Issue:** When multiple supported tabs are open, the popup currently picks the first URL match from `chrome.tabs.query({})`, which may be a non-playing tab. #2 

**Fix:** Select tab by priority:

1. Active (current window)
2. Audible
3. Highest `lastAccessed`

If `sendMessage` fails (`“Receiving end does not exist”` / `“Could not establish connection”`), show a “refresh page / not injected” hint.

### 2. Deezer detection breaks after UI changes #3 

**Issue:** Deezer DOM selectors can change, causing `getCurrentTrack()` to return `null`.

**Fix:** Keep DOM detection as the first method, then fall back to `navigator.mediaSession.metadata` (artist + title).